### PR TITLE
Remove brandbar

### DIFF
--- a/ui/public/viewer.css
+++ b/ui/public/viewer.css
@@ -551,7 +551,7 @@ select {
 
 #sidebarContainer {
   position: absolute;
-  top: 80px;
+  top: 32px;
   bottom: 0;
   width: 400px; /* Here, and elsewhere below, keep the constant value for compatibility
                    with older browsers that lack support for CSS variables. */
@@ -630,7 +630,7 @@ html[dir="rtl"] #sidebarContent {
   overflow: auto;
   -webkit-overflow-scrolling: touch;
   position: absolute;
-  top: 80px;
+  top: 32px;
   right: 0;
   bottom: 0;
   outline: none;
@@ -1720,7 +1720,6 @@ a:focus > .thumbnail > .thumbnailSelectionRing,
   -ms-user-select: none;
   user-select: none;
 }
-
 
 #FAQView,
 #outlineView {

--- a/ui/src/ScholarReader.tsx
+++ b/ui/src/ScholarReader.tsx
@@ -29,11 +29,9 @@ import SearchPageMask from "./components/mask/SearchPageMask";
 import AppOverlay from "./components/overlay/AppOverlay";
 import PageOverlay from "./components/overlay/PageOverlay";
 import ViewerOverlay from "./components/overlay/ViewerOverlay";
-import PdfjsBrandbar from "./components/pdfjs/PdfjsBrandbar";
 import DefinitionPreview from "./components/preview/DefinitionPreview";
 import PrimerPage from "./components/primer/PrimerPage";
 import FAQBar from "./components/questions/FAQBar";
-
 import FindBar, { FindQuery } from "./components/search/FindBar";
 import * as EntitiesTutorial from "./data/annotations_tutorial.json";
 import * as EntitiesSLE from "./data/auto_PAWLS_SPUI_annotations.json";
@@ -908,15 +906,16 @@ export default class ScholarReader extends React.PureComponent<Props, State> {
     let annotationSpanIDs = new Array(entity.attributes.bounding_boxes.length);
     let counter = 0;
     for (let i = 0; i < annotationSpanIDs.length; i++) {
-      
       let pageNumber = entity.attributes.bounding_boxes[i].page;
-      if (i > 0 && pageNumber != entity.attributes.bounding_boxes[i-1].page) {
+      if (i > 0 && pageNumber != entity.attributes.bounding_boxes[i - 1].page) {
         // reset the counter
-        counter = 0
+        counter = 0;
       }
-      annotationSpanIDs[i] = `${annotationID}-page-${pageNumber}-span-${counter}`
+      annotationSpanIDs[
+        i
+      ] = `${annotationID}-page-${pageNumber}-span-${counter}`;
       counter += 1;
-    }  
+    }
 
     // const annotationSpanIDs = entity.attributes.bounding_boxes.map((box, i, boxes) => {
 
@@ -930,9 +929,8 @@ export default class ScholarReader extends React.PureComponent<Props, State> {
     this.selectEntityAnnotation(
       id,
       annotationID,
-      annotationSpanIDs[annotationSpanIDs.length-1]
+      annotationSpanIDs[annotationSpanIDs.length - 1]
     );
-
 
     // if (entity.attributes.bounding_boxes.length > 1) {
     //   this.selectEntityAnnotation(
@@ -1017,7 +1015,7 @@ export default class ScholarReader extends React.PureComponent<Props, State> {
                 </button>
               </PdfjsToolbar>
             ) : null} */}
-            <PdfjsBrandbar />
+            {/* <PdfjsBrandbar /> */}
             <ViewerOverlay
               pdfViewer={this.state.pdfViewer}
               handleSetTextSelection={this.setTextSelection}

--- a/ui/src/style/variables.less
+++ b/ui/src/style/variables.less
@@ -84,7 +84,7 @@
 /**
  * ELEMENT DIMENSIONS
  */
-@brandbar-height: 48px;
+@brandbar-height: 0px;
 @paper-summary-width: 400px;
 @paper-padding: 20px;
 


### PR DESCRIPTION
This commit removes the Semantic Reader brand bar at the top of the page. By removing the brand, I hope to remove any positive or negative associations that users in the study will have with the Semantic Scholar brand, or with whatever else they associate the brand with.

Here is a screenshot of the reader without the brand bar, following the changes in this commit:

![image](https://user-images.githubusercontent.com/2358524/134010571-aceb59cb-d37e-4db5-a34c-f8cad95a9852.png)
