### PR TITLE
Left-align tooltips to the left side of the page

### DIFF
--- a/ui/src/components/common/Tooltip.tsx
+++ b/ui/src/components/common/Tooltip.tsx
@@ -51,7 +51,22 @@ export class Tooltip extends React.PureComponent<Props> {
      * Align the horizontal center of the tooltip with the center of the anchor.
      */
     const anchorPosition = uiUtils.getPositionInPageView(pageView, anchor);
-    const tooltipCenterX = anchorPosition.left + anchorPosition.width + 2;
+    let tooltipCenterX = anchorPosition.left + anchorPosition.width + 2;
+
+    /*
+     * XXX (andrewhead): do not allow an automatically-centered tooltip to appear
+     * off-screen. This hardcodes the maximum width of a tooltip as set in
+     * the '.gloss' class---make sure to change it together with the max-width
+     * property of that class. I do not know whether this will work on glosses
+     * that do not take up the full maximum width of the gloss container.
+     */
+    const MAX_TOOLTIP_WIDTH = 420;
+    if (
+      (placement == "below" || placement == "above") &&
+      tooltipCenterX < MAX_TOOLTIP_WIDTH / 2
+    ) {
+      tooltipCenterX += MAX_TOOLTIP_WIDTH / 2 - tooltipCenterX;
+    }
     let style: React.CSSProperties = {
       left: tooltipCenterX,
       transform: "translate(-50%, 0)",


### PR DESCRIPTION
Now that the FAQs are in the sidebar, some tooltips were getting cut off on the left side when the sidebar was open. Due to the way that the sidebar was implemented, I was not able to use the same trick as before with z-indexing and padding to get the tooltips to render over the sidebar.

So, instead, I hacked something up to constrain the left position of tooltips to always appear within the page, so that it would never overlap with the toolbar.

Here is an example of a tooltip for which the position has been adjusted using the change in this code so that it appears just within the page. 

![image](https://user-images.githubusercontent.com/2358524/134015214-1c71842e-d451-413a-97f9-dd9c9262f285.png)
